### PR TITLE
Remove conflicting dep

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-httpx~=0.23.3
 cryptography~=3.3.1
 python-telegram-bot[job-queue]~=21.7
 SQLAlchemy~=2.0.5


### PR DESCRIPTION
python-telegram-bot will automatically decide the required version of httpx. Specifying it here will cause conflict.